### PR TITLE
feat: add private contribution stats

### DIFF
--- a/.github/workflows/private-contribution-stats.yml
+++ b/.github/workflows/private-contribution-stats.yml
@@ -1,0 +1,55 @@
+name: Private Contribution Stats
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "17 3 * * *"
+
+permissions:
+  contents: write
+  pull-requests: write
+
+env:
+  PROFILE_STATS_TOKEN: ${{ secrets.PROFILE_STATS_TOKEN }}
+
+jobs:
+  generate:
+    name: Generate aggregate private stats
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Validate token
+        if: ${{ env.PROFILE_STATS_TOKEN == '' }}
+        run: |
+          echo "PROFILE_STATS_TOKEN is required to read private repository aggregates."
+          echo "Create a fine-grained token with read-only metadata and contents access for the repositories you want counted."
+          exit 1
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+
+      - name: Generate private contribution SVG
+        run: python scripts/generate_private_contribution_stats.py --output assets/private-contributions.svg --username mashfromband
+
+      - name: Create update pull request
+        uses: peter-evans/create-pull-request@v7
+        with:
+          branch: automation/private-contribution-stats
+          title: "chore: update private contribution stats"
+          commit-message: "chore: update private contribution stats"
+          body: |
+            ## Summary
+
+            - Regenerate aggregate-only private contribution stats for the profile README.
+
+            ## Privacy
+
+            - Private repository names, URLs, issue titles, and commit messages are not written to the SVG.
+          labels: documentation
+          assignees: mashfromband
+          add-paths: |
+            assets/private-contributions.svg

--- a/.github/workflows/profile-readme.yml
+++ b/.github/workflows/profile-readme.yml
@@ -4,12 +4,14 @@ on:
   pull_request:
     paths:
       - "README.md"
+      - "assets/private-contributions.svg"
       - ".github/workflows/profile-readme.yml"
   push:
     branches:
       - main
     paths:
       - "README.md"
+      - "assets/private-contributions.svg"
       - ".github/workflows/profile-readme.yml"
 
 permissions:

--- a/README.md
+++ b/README.md
@@ -114,6 +114,18 @@ RAG / LLM application foundations
 
 ---
 
+## Private Contribution Signals
+
+Public GitHub cards cannot read private repositories, so this section is generated from a private token and published as aggregate-only data. It does not expose private repository names, URLs, issue titles, or commit messages.
+
+<div align="center">
+
+![Private contribution aggregate stats](assets/private-contributions.svg)
+
+</div>
+
+---
+
 ## Operating Principles
 
 - **Spec is the source of truth**: requirements, acceptance criteria, and implementation stay aligned.

--- a/assets/private-contributions.svg
+++ b/assets/private-contributions.svg
@@ -1,0 +1,43 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="260" viewBox="0 0 820 260" role="img" aria-labelledby="title desc">
+  <title id="title">Private contribution aggregate stats for mashfromband</title>
+  <desc id="desc">Aggregate-only private repository activity. Repository names and URLs are not included.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#020617"/>
+      <stop offset="52%" stop-color="#111827"/>
+      <stop offset="100%" stop-color="#312e81"/>
+    </linearGradient>
+    <linearGradient id="accent" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#0ea5e9"/>
+      <stop offset="50%" stop-color="#8b5cf6"/>
+      <stop offset="100%" stop-color="#f97316"/>
+    </linearGradient>
+  </defs>
+  <rect width="820" height="260" rx="24" fill="url(#bg)"/>
+  <rect x="1" y="1" width="818" height="258" rx="23" fill="none" stroke="#334155"/>
+  <rect x="28" y="30" width="186" height="8" rx="4" fill="url(#accent)"/>
+  <text x="28" y="66" fill="#f8fafc" font-family="Segoe UI, Inter, Arial, sans-serif" font-size="26" font-weight="700">Private Work Signals</text>
+  <text x="28" y="212" fill="#cbd5e1" font-family="Segoe UI, Inter, Arial, sans-serif" font-size="14">Top private stack: JavaScript x24, PowerShell x24, TypeScript x19, Python x14</text>
+  <text x="28" y="236" fill="#94a3b8" font-family="Segoe UI, Inter, Arial, sans-serif" font-size="12">Aggregate only. No private repository names, URLs, issue titles, or commit messages are published. Latest private activity: 2026-04-26. Generated: 2026-04-26.</text>
+  
+  <g>
+    <rect x="28" y="86" width="170" height="82" rx="16" fill="#111827" stroke="#334155"/>
+    <text x="46" y="120" fill="#94a3b8" font-size="13">Private repos</text>
+    <text x="46" y="148" fill="#f8fafc" font-size="28" font-weight="700">107</text>
+  </g>
+  <g>
+    <rect x="219" y="86" width="170" height="82" rx="16" fill="#111827" stroke="#334155"/>
+    <text x="237" y="120" fill="#94a3b8" font-size="13">Active in 90 days</text>
+    <text x="237" y="148" fill="#f8fafc" font-size="28" font-weight="700">56</text>
+  </g>
+  <g>
+    <rect x="410" y="86" width="170" height="82" rx="16" fill="#111827" stroke="#334155"/>
+    <text x="428" y="120" fill="#94a3b8" font-size="13">Active in 365 days</text>
+    <text x="428" y="148" fill="#f8fafc" font-size="28" font-weight="700">99</text>
+  </g>
+  <g>
+    <rect x="601" y="86" width="170" height="82" rx="16" fill="#111827" stroke="#334155"/>
+    <text x="619" y="120" fill="#94a3b8" font-size="13">Org workspaces</text>
+    <text x="619" y="148" fill="#f8fafc" font-size="28" font-weight="700">12</text>
+  </g>
+</svg>

--- a/docs/private-contribution-stats.md
+++ b/docs/private-contribution-stats.md
@@ -1,0 +1,43 @@
+# Private Contribution Stats
+
+This profile repository can publish aggregate-only private repository activity in `assets/private-contributions.svg`.
+
+## Privacy Model
+
+The generated SVG may publish:
+
+- Total accessible private repository count
+- Active private repository counts for recent time windows
+- Count of organization-owned private workspaces
+- Top primary languages by count
+- Latest private repository activity date
+
+The generated SVG must not publish:
+
+- Private repository names
+- Private repository URLs
+- Organization names derived only from private access
+- Issue titles
+- Pull request titles
+- Commit messages
+
+## Token Setup
+
+Create a repository secret named `PROFILE_STATS_TOKEN`.
+
+Recommended token type:
+
+- Fine-grained personal access token
+- Read-only access
+- Repository access limited to the private repositories that should be counted
+- Permissions:
+  - Metadata: read
+  - Contents: read
+
+Classic tokens also work with `repo` scope, but fine-grained tokens are preferred.
+
+## Updating Stats
+
+The `Private Contribution Stats` workflow runs on a daily schedule and can also be run manually.
+
+When the generated SVG changes, the workflow opens a pull request instead of pushing directly to `main`.

--- a/scripts/generate_private_contribution_stats.py
+++ b/scripts/generate_private_contribution_stats.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python3
+"""Generate aggregate-only private contribution stats for the profile README.
+
+The generated SVG intentionally avoids repository names, repository URLs, commit
+messages, issue titles, and organization names. It is safe to publish because it
+only contains aggregate counts derived from repositories the token can read.
+"""
+
+from __future__ import annotations
+
+import argparse
+import html
+import json
+import os
+from collections import Counter
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+from urllib.error import HTTPError
+from urllib.parse import urlencode
+from urllib.request import Request, urlopen
+
+
+API_ROOT = "https://api.github.com"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Generate a public-safe SVG from private GitHub repository aggregates."
+    )
+    parser.add_argument("--output", default="assets/private-contributions.svg")
+    parser.add_argument("--username", default=os.getenv("GITHUB_ACTOR", "mashfromband"))
+    return parser.parse_args()
+
+
+def request_json(url: str, token: str) -> tuple[Any, dict[str, str]]:
+    request = Request(
+        url,
+        headers={
+            "Accept": "application/vnd.github+json",
+            "Authorization": f"Bearer {token}",
+            "X-GitHub-Api-Version": "2022-11-28",
+            "User-Agent": "mashfromband-profile-private-stats",
+        },
+    )
+    try:
+        with urlopen(request, timeout=30) as response:
+            payload = json.loads(response.read().decode("utf-8"))
+            headers = {key.lower(): value for key, value in response.headers.items()}
+            return payload, headers
+    except HTTPError as error:
+        detail = error.read().decode("utf-8", errors="replace")
+        raise RuntimeError(f"GitHub API request failed: {error.code} {detail}") from error
+
+
+def parse_link_header(value: str | None) -> dict[str, str]:
+    links: dict[str, str] = {}
+    if not value:
+        return links
+
+    for part in value.split(","):
+        section = part.strip().split(";")
+        if len(section) < 2:
+            continue
+        url = section[0].strip()
+        rel = section[1].strip()
+        if url.startswith("<") and url.endswith(">") and rel.startswith('rel="'):
+            links[rel[5:-1]] = url[1:-1]
+    return links
+
+
+def fetch_private_repositories(token: str) -> list[dict[str, Any]]:
+    params = urlencode(
+        {
+            "visibility": "private",
+            "affiliation": "owner,collaborator,organization_member",
+            "per_page": "100",
+            "sort": "updated",
+            "direction": "desc",
+        }
+    )
+    url = f"{API_ROOT}/user/repos?{params}"
+    repositories: list[dict[str, Any]] = []
+
+    while url:
+        payload, headers = request_json(url, token)
+        if not isinstance(payload, list):
+            raise RuntimeError("Unexpected GitHub API response for /user/repos")
+        repositories.extend(repo for repo in payload if repo.get("private") is True)
+        url = parse_link_header(headers.get("link")).get("next", "")
+
+    return repositories
+
+
+def parse_github_datetime(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    return datetime.fromisoformat(value.replace("Z", "+00:00"))
+
+
+def summarize(repositories: list[dict[str, Any]]) -> dict[str, str]:
+    now = datetime.now(UTC)
+    updated_dates = [
+        parsed
+        for parsed in (parse_github_datetime(repo.get("updated_at")) for repo in repositories)
+        if parsed is not None
+    ]
+    language_counts = Counter(repo.get("language") or "Other" for repo in repositories)
+    organization_count = len(
+        {
+            repo.get("owner", {}).get("login")
+            for repo in repositories
+            if repo.get("owner", {}).get("type") == "Organization"
+        }
+    )
+
+    active_90 = sum(1 for updated_at in updated_dates if updated_at >= now - timedelta(days=90))
+    active_365 = sum(1 for updated_at in updated_dates if updated_at >= now - timedelta(days=365))
+    top_languages = ", ".join(
+        f"{language} x{count}" for language, count in language_counts.most_common(4)
+    )
+
+    return {
+        "private_repos": str(len(repositories)),
+        "active_90": str(active_90),
+        "active_365": str(active_365),
+        "organization_count": str(organization_count),
+        "top_languages": top_languages or "No private languages detected",
+        "latest_update": max(updated_dates).strftime("%Y-%m-%d") if updated_dates else "N/A",
+        "generated_at": now.strftime("%Y-%m-%d"),
+    }
+
+
+def text(value: str) -> str:
+    return html.escape(value, quote=True)
+
+
+def render_svg(summary: dict[str, str], *, username: str, configured: bool) -> str:
+    if not configured:
+        summary = {
+            "private_repos": "Setup",
+            "active_90": "Needed",
+            "active_365": "Needed",
+            "organization_count": "Needed",
+            "top_languages": "Add PROFILE_STATS_TOKEN to generate private contribution aggregates",
+            "latest_update": "N/A",
+            "generated_at": datetime.now(UTC).strftime("%Y-%m-%d"),
+        }
+
+    cards = [
+        ("Private repos", summary["private_repos"]),
+        ("Active in 90 days", summary["active_90"]),
+        ("Active in 365 days", summary["active_365"]),
+        ("Org workspaces", summary["organization_count"]),
+    ]
+    card_svg = []
+    for index, (label, value) in enumerate(cards):
+        x = 28 + index * 191
+        card_svg.append(
+            f"""
+  <g>
+    <rect x="{x}" y="86" width="170" height="82" rx="16" fill="#111827" stroke="#334155"/>
+    <text x="{x + 18}" y="120" fill="#94a3b8" font-size="13">{text(label)}</text>
+    <text x="{x + 18}" y="148" fill="#f8fafc" font-size="28" font-weight="700">{text(value)}</text>
+  </g>"""
+        )
+
+    return f"""<svg xmlns="http://www.w3.org/2000/svg" width="820" height="260" viewBox="0 0 820 260" role="img" aria-labelledby="title desc">
+  <title id="title">Private contribution aggregate stats for {text(username)}</title>
+  <desc id="desc">Aggregate-only private repository activity. Repository names and URLs are not included.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#020617"/>
+      <stop offset="52%" stop-color="#111827"/>
+      <stop offset="100%" stop-color="#312e81"/>
+    </linearGradient>
+    <linearGradient id="accent" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#0ea5e9"/>
+      <stop offset="50%" stop-color="#8b5cf6"/>
+      <stop offset="100%" stop-color="#f97316"/>
+    </linearGradient>
+  </defs>
+  <rect width="820" height="260" rx="24" fill="url(#bg)"/>
+  <rect x="1" y="1" width="818" height="258" rx="23" fill="none" stroke="#334155"/>
+  <rect x="28" y="30" width="186" height="8" rx="4" fill="url(#accent)"/>
+  <text x="28" y="66" fill="#f8fafc" font-family="Segoe UI, Inter, Arial, sans-serif" font-size="26" font-weight="700">Private Work Signals</text>
+  <text x="28" y="212" fill="#cbd5e1" font-family="Segoe UI, Inter, Arial, sans-serif" font-size="14">Top private stack: {text(summary["top_languages"])}</text>
+  <text x="28" y="236" fill="#94a3b8" font-family="Segoe UI, Inter, Arial, sans-serif" font-size="12">Aggregate only. No private repository names, URLs, issue titles, or commit messages are published. Latest private activity: {text(summary["latest_update"])}. Generated: {text(summary["generated_at"])}.</text>
+  {''.join(card_svg)}
+</svg>
+"""
+
+
+def main() -> None:
+    args = parse_args()
+    token = os.getenv("PROFILE_STATS_TOKEN") or os.getenv("GH_TOKEN") or os.getenv("GITHUB_TOKEN")
+    configured = bool(token)
+
+    repositories = fetch_private_repositories(token) if token else []
+    summary = summarize(repositories)
+    output = Path(args.output)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(
+        render_svg(summary, username=args.username, configured=configured),
+        encoding="utf-8",
+        newline="\n",
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Add an aggregate-only private contribution SVG to the profile README.
- Add a Python generator that reads private repositories through a token and publishes only aggregate counts.
- Add a scheduled/manual workflow that regenerates the SVG and opens an update PR.
- Document `PROFILE_STATS_TOKEN` setup and privacy boundaries.

## Privacy

- Private repository names, URLs, issue titles, PR titles, and commit messages are not written to the SVG.
- The generated README asset publishes counts and language aggregates only.

## Test plan

- Generated `assets/private-contributions.svg` from the current authenticated GitHub account.
- Verified private repository names and URLs are not present in repository files.
- Ran Python syntax check in Docker: `docker run --rm -v "${PWD}:/work" -w /work python:3.13-alpine python -m py_compile scripts/generate_private_contribution_stats.py`.
- Verified Cursor diagnostics report no linter errors for changed files.

Closes #7
