### PR TITLE
feat: count all accessible repository activity

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,9 +97,9 @@ RAG / LLM application foundations
 
 </div>
 
-## Private Contribution Signals
+## All Activity Signals
 
-Public GitHub cards cannot read every private contribution, so this section is generated from a private token and published as aggregate-only data across accessible repositories. It includes streaks, total contributions, reviews, pull requests, and repository activity without exposing repository names, URLs, issue titles, or commit messages.
+Public GitHub cards cannot read every private repository activity, so this section is generated from a private token and published as aggregate-only data across accessible repositories. It includes streaks, total activity, commits, issues, reviewed pull requests, authored pull requests, and repository activity without exposing repository names, URLs, issue titles, or commit messages.
 
 <div align="center">
 

--- a/assets/private-contributions.svg
+++ b/assets/private-contributions.svg
@@ -1,6 +1,6 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="368" viewBox="0 0 820 368" role="img" aria-labelledby="title desc">
-  <title id="title">Aggregate contribution stats for mashfromband</title>
-  <desc id="desc">Aggregate contribution and repository activity. Repository names and URLs are not included.</desc>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="460" viewBox="0 0 820 460" role="img" aria-labelledby="title desc">
+  <title id="title">Aggregate activity stats for mashfromband</title>
+  <desc id="desc">Aggregate activity across accessible repositories. Repository names and URLs are not included.</desc>
   <defs>
     <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
       <stop offset="0%" stop-color="#020617"/>
@@ -13,52 +13,57 @@
       <stop offset="100%" stop-color="#f97316"/>
     </linearGradient>
   </defs>
-  <rect width="820" height="368" rx="24" fill="url(#bg)"/>
-  <rect x="1" y="1" width="818" height="366" rx="23" fill="none" stroke="#334155"/>
+  <rect width="820" height="460" rx="24" fill="url(#bg)"/>
+  <rect x="1" y="1" width="818" height="458" rx="23" fill="none" stroke="#334155"/>
   <rect x="28" y="30" width="186" height="8" rx="4" fill="url(#accent)"/>
-  <text x="28" y="66" fill="#f8fafc" font-family="Segoe UI, Inter, Arial, sans-serif" font-size="26" font-weight="700">Contribution Signals</text>
-  <text x="28" y="292" fill="#cbd5e1" font-family="Segoe UI, Inter, Arial, sans-serif" font-size="14">Accessible repos: 112 total / 107 private / 5 public / 12 org workspaces</text>
-  <text x="28" y="316" fill="#cbd5e1" font-family="Segoe UI, Inter, Arial, sans-serif" font-size="14">Top stack across accessible repos: PowerShell x28, JavaScript x24, TypeScript x19, Python x15</text>
-  <text x="28" y="342" fill="#94a3b8" font-family="Segoe UI, Inter, Arial, sans-serif" font-size="12">Aggregate only. No repository names, URLs, issue titles, or commit messages are published. Latest repo activity: 2026-04-26. Generated: 2026-04-26.</text>
+  <text x="28" y="66" fill="#f8fafc" font-family="Segoe UI, Inter, Arial, sans-serif" font-size="26" font-weight="700">All Activity Signals</text>
+  <text x="28" y="386" fill="#cbd5e1" font-family="Segoe UI, Inter, Arial, sans-serif" font-size="14">Accessible repos: 112 total / 107 private / 5 public / 12 org workspaces</text>
+  <text x="28" y="410" fill="#cbd5e1" font-family="Segoe UI, Inter, Arial, sans-serif" font-size="14">Top stack across accessible repos: PowerShell x28, JavaScript x24, TypeScript x19, Python x15</text>
+  <text x="28" y="436" fill="#94a3b8" font-family="Segoe UI, Inter, Arial, sans-serif" font-size="12">Aggregate only. No repository names, URLs, issue titles, or commit messages are published. Latest repo activity: 2026-04-26. Generated: 2026-04-26.</text>
   
   <g>
     <rect x="28" y="86" width="170" height="82" rx="16" fill="#111827" stroke="#334155"/>
-    <text x="46" y="120" fill="#94a3b8" font-size="13">Total</text>
-    <text x="46" y="148" fill="#f8fafc" font-size="28" font-weight="700">23</text>
+    <text x="46" y="120" fill="#94a3b8" font-size="13">Total activity</text>
+    <text x="46" y="148" fill="#f8fafc" font-size="28" font-weight="700">5654</text>
   </g>
   <g>
     <rect x="219" y="86" width="170" height="82" rx="16" fill="#111827" stroke="#334155"/>
     <text x="237" y="120" fill="#94a3b8" font-size="13">Current streak</text>
-    <text x="237" y="148" fill="#f8fafc" font-size="28" font-weight="700">1d</text>
+    <text x="237" y="148" fill="#f8fafc" font-size="28" font-weight="700">2d</text>
   </g>
   <g>
     <rect x="410" y="86" width="170" height="82" rx="16" fill="#111827" stroke="#334155"/>
     <text x="428" y="120" fill="#94a3b8" font-size="13">Longest streak</text>
-    <text x="428" y="148" fill="#f8fafc" font-size="28" font-weight="700">1d</text>
+    <text x="428" y="148" fill="#f8fafc" font-size="28" font-weight="700">8d</text>
   </g>
   <g>
     <rect x="601" y="86" width="170" height="82" rx="16" fill="#111827" stroke="#334155"/>
     <text x="619" y="120" fill="#94a3b8" font-size="13">Active days</text>
-    <text x="619" y="148" fill="#f8fafc" font-size="28" font-weight="700">2</text>
+    <text x="619" y="148" fill="#f8fafc" font-size="28" font-weight="700">51</text>
   </g>
   <g>
     <rect x="28" y="178" width="170" height="82" rx="16" fill="#111827" stroke="#334155"/>
     <text x="46" y="212" fill="#94a3b8" font-size="13">Commits</text>
-    <text x="46" y="240" fill="#f8fafc" font-size="28" font-weight="700">15</text>
+    <text x="46" y="240" fill="#f8fafc" font-size="28" font-weight="700">3154</text>
   </g>
   <g>
     <rect x="219" y="178" width="170" height="82" rx="16" fill="#111827" stroke="#334155"/>
     <text x="237" y="212" fill="#94a3b8" font-size="13">Pull requests</text>
-    <text x="237" y="240" fill="#f8fafc" font-size="28" font-weight="700">5</text>
+    <text x="237" y="240" fill="#f8fafc" font-size="28" font-weight="700">1249</text>
   </g>
   <g>
     <rect x="410" y="178" width="170" height="82" rx="16" fill="#111827" stroke="#334155"/>
-    <text x="428" y="212" fill="#94a3b8" font-size="13">Reviews</text>
-    <text x="428" y="240" fill="#f8fafc" font-size="28" font-weight="700">0</text>
+    <text x="428" y="212" fill="#94a3b8" font-size="13">Issues</text>
+    <text x="428" y="240" fill="#f8fafc" font-size="28" font-weight="700">1021</text>
   </g>
   <g>
     <rect x="601" y="178" width="170" height="82" rx="16" fill="#111827" stroke="#334155"/>
-    <text x="619" y="212" fill="#94a3b8" font-size="13">Repos touched</text>
-    <text x="619" y="240" fill="#f8fafc" font-size="28" font-weight="700">112</text>
+    <text x="619" y="212" fill="#94a3b8" font-size="13">Reviewed PRs</text>
+    <text x="619" y="240" fill="#f8fafc" font-size="28" font-weight="700">230</text>
+  </g>
+  <g>
+    <rect x="28" y="270" width="170" height="82" rx="16" fill="#111827" stroke="#334155"/>
+    <text x="46" y="304" fill="#94a3b8" font-size="13">Repos touched</text>
+    <text x="46" y="332" fill="#f8fafc" font-size="28" font-weight="700">104</text>
   </g>
 </svg>

--- a/docs/private-contribution-stats.md
+++ b/docs/private-contribution-stats.md
@@ -1,16 +1,16 @@
 # Private Contribution Stats
 
-This profile repository can publish aggregate-only contribution activity in `assets/private-contributions.svg`.
+This profile repository can publish aggregate-only activity across accessible repositories in `assets/private-contributions.svg`.
 
 ## Privacy Model
 
 The generated SVG may publish:
 
-- Total contributions over the last year
-- Current contribution streak
-- Longest contribution streak
-- Active contribution days
-- Commit, pull request, and review contribution totals
+- Total activity over the last year
+- Current activity streak
+- Longest activity streak
+- Active activity days
+- Commit, authored pull request, authored issue, and reviewed pull request totals
 - Total accessible repository count
 - Private and public repository counts
 - Active repository counts for recent time windows
@@ -39,8 +39,21 @@ Recommended token type:
 - Permissions:
   - Metadata: read
   - Contents: read
+  - Issues: read
+  - Pull requests: read
 
 Classic tokens also work with `repo` scope, but fine-grained tokens are preferred.
+
+## Counting Model
+
+The script does not rely on GitHub's profile contribution calendar. Instead, it scans accessible repositories and GitHub search results to count:
+
+- Commits authored by `mashfromband`
+- Pull requests authored by `mashfromband`
+- Issues authored by `mashfromband`
+- Pull requests reviewed by `mashfromband`
+
+This is intended to represent practical work across public and private repositories more accurately than public profile cards.
 
 ## Updating Stats
 

--- a/scripts/generate_private_contribution_stats.py
+++ b/scripts/generate_private_contribution_stats.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
-"""Generate aggregate-only contribution stats for the profile README.
+"""Generate aggregate-only activity stats for the profile README.
 
 The generated SVG intentionally avoids repository names, repository URLs, commit
 messages, issue titles, and organization names. It is safe to publish because it
-only contains aggregate counts derived from contribution and repository metadata
-the token can read.
+only contains aggregate counts derived from repository activity metadata the token
+can read.
 """
 
 from __future__ import annotations
@@ -13,25 +13,30 @@ import argparse
 import html
 import json
 import os
+import socket
 from collections import Counter
 from datetime import UTC, datetime, timedelta
+from http.client import IncompleteRead
 from pathlib import Path
 from typing import Any
-from urllib.error import HTTPError
+from urllib.error import HTTPError, URLError
 from urllib.parse import urlencode
 from urllib.request import Request, urlopen
 
 
 API_ROOT = "https://api.github.com"
-GRAPHQL_ROOT = "https://api.github.com/graphql"
+REQUEST_TIMEOUT_SECONDS = 20
+REQUEST_RETRIES = 1
+SEARCH_DATE_SAMPLE_PAGES = 5
 
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
-        description="Generate a public-safe SVG from aggregate GitHub contribution data."
+        description="Generate a public-safe SVG from aggregate GitHub activity data."
     )
     parser.add_argument("--output", default="assets/private-contributions.svg")
     parser.add_argument("--username", default=os.getenv("GITHUB_ACTOR", "mashfromband"))
+    parser.add_argument("--days", type=int, default=365)
     return parser.parse_args()
 
 
@@ -45,38 +50,20 @@ def request_json(url: str, token: str) -> tuple[Any, dict[str, str]]:
             "User-Agent": "mashfromband-profile-private-stats",
         },
     )
-    try:
-        with urlopen(request, timeout=30) as response:
-            payload = json.loads(response.read().decode("utf-8"))
-            headers = {key.lower(): value for key, value in response.headers.items()}
-            return payload, headers
-    except HTTPError as error:
-        detail = error.read().decode("utf-8", errors="replace")
-        raise RuntimeError(f"GitHub API request failed: {error.code} {detail}") from error
+    for attempt in range(1, REQUEST_RETRIES + 1):
+        try:
+            with urlopen(request, timeout=REQUEST_TIMEOUT_SECONDS) as response:
+                payload = json.loads(response.read().decode("utf-8"))
+                headers = {key.lower(): value for key, value in response.headers.items()}
+                return payload, headers
+        except HTTPError as error:
+            detail = error.read().decode("utf-8", errors="replace")
+            raise RuntimeError(f"GitHub API request failed: {error.code} {detail}") from error
+        except (IncompleteRead, TimeoutError, socket.timeout, URLError) as error:
+            if attempt == REQUEST_RETRIES:
+                raise RuntimeError(f"GitHub API request timed out after retries: {url}") from error
 
-
-def request_graphql(query: str, variables: dict[str, Any], token: str) -> dict[str, Any]:
-    request = Request(
-        GRAPHQL_ROOT,
-        data=json.dumps({"query": query, "variables": variables}).encode("utf-8"),
-        headers={
-            "Accept": "application/vnd.github+json",
-            "Authorization": f"Bearer {token}",
-            "Content-Type": "application/json",
-            "User-Agent": "mashfromband-profile-private-stats",
-        },
-        method="POST",
-    )
-    try:
-        with urlopen(request, timeout=30) as response:
-            payload = json.loads(response.read().decode("utf-8"))
-    except HTTPError as error:
-        detail = error.read().decode("utf-8", errors="replace")
-        raise RuntimeError(f"GitHub GraphQL request failed: {error.code} {detail}") from error
-
-    if payload.get("errors"):
-        raise RuntimeError(f"GitHub GraphQL returned errors: {payload['errors']}")
-    return payload["data"]
+    raise RuntimeError(f"GitHub API request failed unexpectedly: {url}")
 
 
 def parse_link_header(value: str | None) -> dict[str, str]:
@@ -118,43 +105,80 @@ def fetch_accessible_repositories(token: str) -> list[dict[str, Any]]:
     return repositories
 
 
-def fetch_contribution_calendar(token: str, username: str) -> dict[str, Any]:
-    to_date = datetime.now(UTC)
-    from_date = to_date - timedelta(days=365)
-    data = request_graphql(
-        """
-        query($login: String!, $from: DateTime!, $to: DateTime!) {
-          user(login: $login) {
-            contributionsCollection(from: $from, to: $to) {
-              contributionCalendar {
-                totalContributions
-                weeks {
-                  contributionDays {
-                    date
-                    contributionCount
-                  }
-                }
-              }
-              restrictedContributionsCount
-              totalCommitContributions
-              totalIssueContributions
-              totalPullRequestContributions
-              totalPullRequestReviewContributions
-            }
-          }
-        }
-        """,
+def fetch_commit_activity(
+    repositories: list[dict[str, Any]], token: str, username: str, since: datetime
+) -> tuple[int, Counter[str]]:
+    _ = repositories
+    since_date = since.date().isoformat()
+    query = f"author:{username} committer-date:>={since_date}"
+    params = urlencode(
         {
-            "login": username,
-            "from": from_date.isoformat(),
-            "to": to_date.isoformat(),
-        },
-        token,
+            "q": query,
+            "per_page": "100",
+            "sort": "committer-date",
+            "order": "desc",
+        }
     )
-    user = data.get("user")
-    if not user:
-        raise RuntimeError(f"GitHub user not found: {username}")
-    return user["contributionsCollection"]
+    url = f"{API_ROOT}/search/commits?{params}"
+    activity_dates: Counter[str] = Counter()
+
+    total = 0
+    sampled_pages = 0
+    while url and sampled_pages < SEARCH_DATE_SAMPLE_PAGES:
+        sampled_pages += 1
+        try:
+            payload, headers = request_json(url, token)
+        except RuntimeError as error:
+            if "timed out" in str(error):
+                break
+            raise
+        if not isinstance(payload, dict) or not isinstance(payload.get("items"), list):
+            raise RuntimeError("Unexpected GitHub API response for search/commits")
+
+        total = max(total, int(payload.get("total_count", 0)))
+        for item in payload["items"]:
+            commit_date = (
+                item.get("commit", {}).get("author", {}).get("date")
+                or item.get("commit", {}).get("committer", {}).get("date")
+            )
+            parsed = parse_github_datetime(commit_date)
+            if parsed:
+                activity_dates[parsed.date().isoformat()] += 1
+
+        url = parse_link_header(headers.get("link")).get("next", "")
+
+    return total, activity_dates
+
+
+def fetch_search_activity(
+    token: str, query: str, date_field: str
+) -> tuple[int, Counter[str]]:
+    params = urlencode({"q": query, "per_page": "100", "sort": "created", "order": "desc"})
+    url = f"{API_ROOT}/search/issues?{params}"
+    total = 0
+    activity_dates: Counter[str] = Counter()
+
+    sampled_pages = 0
+    while url and sampled_pages < SEARCH_DATE_SAMPLE_PAGES:
+        sampled_pages += 1
+        try:
+            payload, headers = request_json(url, token)
+        except RuntimeError as error:
+            if "timed out" in str(error):
+                break
+            raise
+        if not isinstance(payload, dict) or not isinstance(payload.get("items"), list):
+            raise RuntimeError("Unexpected GitHub API response for search/issues")
+
+        total = max(total, int(payload.get("total_count", 0)))
+        for item in payload["items"]:
+            parsed = parse_github_datetime(item.get(date_field))
+            if parsed:
+                activity_dates[parsed.date().isoformat()] += 1
+
+        url = parse_link_header(headers.get("link")).get("next", "")
+
+    return total, activity_dates
 
 
 def parse_github_datetime(value: str | None) -> datetime | None:
@@ -163,12 +187,13 @@ def parse_github_datetime(value: str | None) -> datetime | None:
     return datetime.fromisoformat(value.replace("Z", "+00:00"))
 
 
-def calculate_streaks(days: list[dict[str, Any]]) -> dict[str, int]:
-    parsed_days = [
-        (datetime.strptime(day["date"], "%Y-%m-%d").date(), int(day["contributionCount"]))
-        for day in days
-    ]
-    parsed_days.sort(key=lambda item: item[0])
+def calculate_streaks(activity_dates: Counter[str], since: datetime, today: datetime) -> dict[str, int]:
+    parsed_days = []
+    current_day = since.date()
+    end_day = today.date()
+    while current_day <= end_day:
+        parsed_days.append((current_day, activity_dates[current_day.isoformat()]))
+        current_day += timedelta(days=1)
 
     longest = 0
     running = 0
@@ -194,8 +219,41 @@ def calculate_streaks(days: list[dict[str, Any]]) -> dict[str, int]:
     return {"current": current, "longest": longest, "active_days": active_days}
 
 
+def collect_activity(
+    repositories: list[dict[str, Any]], token: str, username: str, days: int
+) -> dict[str, Any]:
+    now = datetime.now(UTC)
+    since = now - timedelta(days=days)
+    since_date = since.date().isoformat()
+
+    commit_count, activity_dates = fetch_commit_activity(repositories, token, username, since)
+
+    authored_pr_count, pr_dates = fetch_search_activity(
+        token, f"author:{username} type:pr created:>={since_date}", "created_at"
+    )
+    issue_count, issue_dates = fetch_search_activity(
+        token, f"author:{username} type:issue created:>={since_date}", "created_at"
+    )
+    reviewed_pr_count, review_dates = fetch_search_activity(
+        token, f"reviewed-by:{username} type:pr updated:>={since_date}", "updated_at"
+    )
+
+    activity_dates.update(pr_dates)
+    activity_dates.update(issue_dates)
+    activity_dates.update(review_dates)
+
+    return {
+        "commit_count": commit_count,
+        "authored_pr_count": authored_pr_count,
+        "issue_count": issue_count,
+        "reviewed_pr_count": reviewed_pr_count,
+        "activity_dates": activity_dates,
+        "streaks": calculate_streaks(activity_dates, since, now),
+    }
+
+
 def summarize(
-    repositories: list[dict[str, Any]], contributions: dict[str, Any] | None
+    repositories: list[dict[str, Any]], activity: dict[str, Any] | None
 ) -> dict[str, str]:
     now = datetime.now(UTC)
     updated_dates = [
@@ -220,23 +278,23 @@ def summarize(
         f"{language} x{count}" for language, count in language_counts.most_common(4)
     )
 
-    calendar = (contributions or {}).get("contributionCalendar", {})
-    days = [
-        day
-        for week in calendar.get("weeks", [])
-        for day in week.get("contributionDays", [])
-    ]
-    streaks = calculate_streaks(days) if days else {"current": 0, "longest": 0, "active_days": 0}
+    activity = activity or {}
+    streaks = activity.get("streaks") or {"current": 0, "longest": 0, "active_days": 0}
+    commit_count = int(activity.get("commit_count", 0))
+    authored_pr_count = int(activity.get("authored_pr_count", 0))
+    issue_count = int(activity.get("issue_count", 0))
+    reviewed_pr_count = int(activity.get("reviewed_pr_count", 0))
+    total_activity = commit_count + authored_pr_count + issue_count + reviewed_pr_count
 
     return {
-        "total_contributions": str(calendar.get("totalContributions", 0)),
+        "total_contributions": str(total_activity),
         "current_streak": str(streaks["current"]),
         "longest_streak": str(streaks["longest"]),
         "active_days": str(streaks["active_days"]),
-        "commit_contributions": str((contributions or {}).get("totalCommitContributions", 0)),
-        "pull_requests": str((contributions or {}).get("totalPullRequestContributions", 0)),
-        "reviews": str((contributions or {}).get("totalPullRequestReviewContributions", 0)),
-        "restricted_contributions": str((contributions or {}).get("restrictedContributionsCount", 0)),
+        "commit_contributions": str(commit_count),
+        "pull_requests": str(authored_pr_count),
+        "issues": str(issue_count),
+        "reviews": str(reviewed_pr_count),
         "accessible_repos": str(len(repositories)),
         "private_repos": str(private_count),
         "public_repos": str(public_count),
@@ -262,28 +320,29 @@ def render_svg(summary: dict[str, str], *, username: str, configured: bool) -> s
             "active_days": "Needed",
             "commit_contributions": "Needed",
             "pull_requests": "Needed",
+            "issues": "Needed",
             "reviews": "Needed",
-            "restricted_contributions": "Needed",
             "accessible_repos": "Setup",
             "private_repos": "Setup",
             "public_repos": "Setup",
             "active_90": "Needed",
             "active_365": "Needed",
             "organization_count": "Needed",
-            "top_languages": "Add PROFILE_STATS_TOKEN to generate aggregate contribution signals",
+            "top_languages": "Add PROFILE_STATS_TOKEN to generate aggregate activity signals",
             "latest_update": "N/A",
             "generated_at": datetime.now(UTC).strftime("%Y-%m-%d"),
         }
 
     cards = [
-        ("Total", summary["total_contributions"]),
+        ("Total activity", summary["total_contributions"]),
         ("Current streak", f'{summary["current_streak"]}d'),
         ("Longest streak", f'{summary["longest_streak"]}d'),
         ("Active days", summary["active_days"]),
         ("Commits", summary["commit_contributions"]),
         ("Pull requests", summary["pull_requests"]),
-        ("Reviews", summary["reviews"]),
-        ("Repos touched", summary["accessible_repos"]),
+        ("Issues", summary["issues"]),
+        ("Reviewed PRs", summary["reviews"]),
+        ("Repos touched", summary["active_365"]),
     ]
     card_svg = []
     for index, (label, value) in enumerate(cards):
@@ -300,9 +359,9 @@ def render_svg(summary: dict[str, str], *, username: str, configured: bool) -> s
   </g>"""
         )
 
-    return f"""<svg xmlns="http://www.w3.org/2000/svg" width="820" height="368" viewBox="0 0 820 368" role="img" aria-labelledby="title desc">
-  <title id="title">Aggregate contribution stats for {text(username)}</title>
-  <desc id="desc">Aggregate contribution and repository activity. Repository names and URLs are not included.</desc>
+    return f"""<svg xmlns="http://www.w3.org/2000/svg" width="820" height="460" viewBox="0 0 820 460" role="img" aria-labelledby="title desc">
+  <title id="title">Aggregate activity stats for {text(username)}</title>
+  <desc id="desc">Aggregate activity across accessible repositories. Repository names and URLs are not included.</desc>
   <defs>
     <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
       <stop offset="0%" stop-color="#020617"/>
@@ -315,13 +374,13 @@ def render_svg(summary: dict[str, str], *, username: str, configured: bool) -> s
       <stop offset="100%" stop-color="#f97316"/>
     </linearGradient>
   </defs>
-  <rect width="820" height="368" rx="24" fill="url(#bg)"/>
-  <rect x="1" y="1" width="818" height="366" rx="23" fill="none" stroke="#334155"/>
+  <rect width="820" height="460" rx="24" fill="url(#bg)"/>
+  <rect x="1" y="1" width="818" height="458" rx="23" fill="none" stroke="#334155"/>
   <rect x="28" y="30" width="186" height="8" rx="4" fill="url(#accent)"/>
-  <text x="28" y="66" fill="#f8fafc" font-family="Segoe UI, Inter, Arial, sans-serif" font-size="26" font-weight="700">Contribution Signals</text>
-  <text x="28" y="292" fill="#cbd5e1" font-family="Segoe UI, Inter, Arial, sans-serif" font-size="14">Accessible repos: {text(summary["accessible_repos"])} total / {text(summary["private_repos"])} private / {text(summary["public_repos"])} public / {text(summary["organization_count"])} org workspaces</text>
-  <text x="28" y="316" fill="#cbd5e1" font-family="Segoe UI, Inter, Arial, sans-serif" font-size="14">Top stack across accessible repos: {text(summary["top_languages"])}</text>
-  <text x="28" y="342" fill="#94a3b8" font-family="Segoe UI, Inter, Arial, sans-serif" font-size="12">Aggregate only. No repository names, URLs, issue titles, or commit messages are published. Latest repo activity: {text(summary["latest_update"])}. Generated: {text(summary["generated_at"])}.</text>
+  <text x="28" y="66" fill="#f8fafc" font-family="Segoe UI, Inter, Arial, sans-serif" font-size="26" font-weight="700">All Activity Signals</text>
+  <text x="28" y="386" fill="#cbd5e1" font-family="Segoe UI, Inter, Arial, sans-serif" font-size="14">Accessible repos: {text(summary["accessible_repos"])} total / {text(summary["private_repos"])} private / {text(summary["public_repos"])} public / {text(summary["organization_count"])} org workspaces</text>
+  <text x="28" y="410" fill="#cbd5e1" font-family="Segoe UI, Inter, Arial, sans-serif" font-size="14">Top stack across accessible repos: {text(summary["top_languages"])}</text>
+  <text x="28" y="436" fill="#94a3b8" font-family="Segoe UI, Inter, Arial, sans-serif" font-size="12">Aggregate only. No repository names, URLs, issue titles, or commit messages are published. Latest repo activity: {text(summary["latest_update"])}. Generated: {text(summary["generated_at"])}.</text>
   {''.join(card_svg)}
 </svg>
 """
@@ -333,8 +392,8 @@ def main() -> None:
     configured = bool(token)
 
     repositories = fetch_accessible_repositories(token) if token else []
-    contributions = fetch_contribution_calendar(token, args.username) if token else None
-    summary = summarize(repositories, contributions)
+    activity = collect_activity(repositories, token, args.username, args.days) if token else None
+    summary = summarize(repositories, activity)
     output = Path(args.output)
     output.parent.mkdir(parents=True, exist_ok=True)
     output.write_text(


### PR DESCRIPTION
## Summary

- Replace GitHub contribution-calendar based metrics with aggregate activity counts from accessible repositories and GitHub Search API.
- Count commits, authored PRs, authored issues, reviewed PRs, streaks, active days, and repositories touched across public and private repositories that the token can read.
- Rename the README section to `All Activity Signals` and update the SVG output.
- Keep the privacy boundary: repository names, URLs, issue titles, PR titles, and commit messages are not written to the SVG.

## Test plan

- Generated `assets/private-contributions.svg` with the current authenticated GitHub account.
- Verified private repository names and URLs are not present in repository files.
- Ran Python syntax check in Docker: `docker run --rm -v "${PWD}:/work" -w /work python:3.13-alpine python -m py_compile scripts/generate_private_contribution_stats.py`.
- Verified Cursor diagnostics report no linter errors for changed files.
