### PR TITLE
feat: refine all activity signals card

### DIFF
--- a/.github/workflows/private-contribution-stats.yml
+++ b/.github/workflows/private-contribution-stats.yml
@@ -1,8 +1,9 @@
-name: Private Contribution Stats
+name: All Activity Signals
 
 on:
   workflow_dispatch:
   schedule:
+    # Daily keeps the profile current while staying lightweight for a public profile repository.
     - cron: "17 3 * * *"
 
 permissions:
@@ -14,7 +15,7 @@ env:
 
 jobs:
   generate:
-    name: Generate aggregate private stats
+    name: Generate aggregate activity stats
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -32,19 +33,20 @@ jobs:
         with:
           python-version: "3.13"
 
-      - name: Generate private contribution SVG
+      - name: Generate activity signals SVG
         run: python scripts/generate_private_contribution_stats.py --output assets/private-contributions.svg --username mashfromband
 
       - name: Create update pull request
         uses: peter-evans/create-pull-request@v7
         with:
-          branch: automation/private-contribution-stats
-          title: "chore: update private contribution stats"
-          commit-message: "chore: update private contribution stats"
+          branch: automation/all-activity-signals
+          title: "chore: update all activity signals"
+          commit-message: "chore: update all activity signals"
           body: |
             ## Summary
 
-            - Regenerate aggregate-only private contribution stats for the profile README.
+            - Regenerate aggregate-only activity signals for the profile README.
+            - Runs daily to keep the profile current without publishing private repository details.
 
             ## Privacy
 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ RAG / LLM application foundations
 
 ## All Activity Signals
 
-Public GitHub cards cannot read every private repository activity, so this section is generated from a private token and published as aggregate-only data across accessible repositories. It includes streaks, total activity, commits, issues, reviewed pull requests, authored pull requests, and repository activity without exposing repository names, URLs, issue titles, or commit messages.
+Public GitHub cards cannot read every private repository activity, so this section is generated from a private token and published as aggregate-only data across accessible repositories. It highlights total activity, commits, issues, reviewed pull requests, authored pull requests, accessible repository coverage, and top stack signals without exposing repository names, URLs, issue titles, or commit messages.
 
 <div align="center">
 

--- a/assets/private-contributions.svg
+++ b/assets/private-contributions.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="460" viewBox="0 0 820 460" role="img" aria-labelledby="title desc">
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="388" viewBox="0 0 820 388" role="img" aria-labelledby="title desc">
   <title id="title">Aggregate activity stats for mashfromband</title>
   <desc id="desc">Aggregate activity across accessible repositories. Repository names and URLs are not included.</desc>
   <defs>
@@ -13,57 +13,52 @@
       <stop offset="100%" stop-color="#f97316"/>
     </linearGradient>
   </defs>
-  <rect width="820" height="460" rx="24" fill="url(#bg)"/>
-  <rect x="1" y="1" width="818" height="458" rx="23" fill="none" stroke="#334155"/>
+  <rect width="820" height="388" rx="24" fill="url(#bg)"/>
+  <rect x="1" y="1" width="818" height="386" rx="23" fill="none" stroke="#334155"/>
   <rect x="28" y="30" width="186" height="8" rx="4" fill="url(#accent)"/>
   <text x="28" y="66" fill="#f8fafc" font-family="Segoe UI, Inter, Arial, sans-serif" font-size="26" font-weight="700">All Activity Signals</text>
-  <text x="28" y="386" fill="#cbd5e1" font-family="Segoe UI, Inter, Arial, sans-serif" font-size="14">Accessible repos: 112 total / 107 private / 5 public / 12 org workspaces</text>
-  <text x="28" y="410" fill="#cbd5e1" font-family="Segoe UI, Inter, Arial, sans-serif" font-size="14">Top stack across accessible repos: PowerShell x28, JavaScript x24, TypeScript x19, Python x15</text>
-  <text x="28" y="436" fill="#94a3b8" font-family="Segoe UI, Inter, Arial, sans-serif" font-size="12">Aggregate only. No repository names, URLs, issue titles, or commit messages are published. Latest repo activity: 2026-04-26. Generated: 2026-04-26.</text>
+  <text x="28" y="314" fill="#cbd5e1" font-family="Segoe UI, Inter, Arial, sans-serif" font-size="14">Stack detail: PowerShell x28, JavaScript x24, TypeScript x19, Python x15</text>
+  <text x="28" y="340" fill="#94a3b8" font-family="Segoe UI, Inter, Arial, sans-serif" font-size="12">Repo split: 107 private / 5 public / 12 org workspaces. Daily automation-friendly aggregate.</text>
+  <text x="28" y="362" fill="#94a3b8" font-family="Segoe UI, Inter, Arial, sans-serif" font-size="12">No repository names, URLs, issue titles, or commit messages are published. Latest repo activity: 2026-04-26. Generated: 2026-04-27.</text>
   
   <g>
     <rect x="28" y="86" width="170" height="82" rx="16" fill="#111827" stroke="#334155"/>
     <text x="46" y="120" fill="#94a3b8" font-size="13">Total activity</text>
-    <text x="46" y="148" fill="#f8fafc" font-size="28" font-weight="700">5654</text>
+    <text x="46" y="148" fill="#f8fafc" font-size="28" font-weight="700">5678</text>
   </g>
   <g>
     <rect x="219" y="86" width="170" height="82" rx="16" fill="#111827" stroke="#334155"/>
-    <text x="237" y="120" fill="#94a3b8" font-size="13">Current streak</text>
-    <text x="237" y="148" fill="#f8fafc" font-size="28" font-weight="700">2d</text>
+    <text x="237" y="120" fill="#94a3b8" font-size="13">Commits</text>
+    <text x="237" y="148" fill="#f8fafc" font-size="28" font-weight="700">3162</text>
   </g>
   <g>
     <rect x="410" y="86" width="170" height="82" rx="16" fill="#111827" stroke="#334155"/>
-    <text x="428" y="120" fill="#94a3b8" font-size="13">Longest streak</text>
-    <text x="428" y="148" fill="#f8fafc" font-size="28" font-weight="700">8d</text>
+    <text x="428" y="120" fill="#94a3b8" font-size="13">Pull requests</text>
+    <text x="428" y="148" fill="#f8fafc" font-size="28" font-weight="700">1257</text>
   </g>
   <g>
     <rect x="601" y="86" width="170" height="82" rx="16" fill="#111827" stroke="#334155"/>
-    <text x="619" y="120" fill="#94a3b8" font-size="13">Active days</text>
-    <text x="619" y="148" fill="#f8fafc" font-size="28" font-weight="700">51</text>
+    <text x="619" y="120" fill="#94a3b8" font-size="13">Issues</text>
+    <text x="619" y="148" fill="#f8fafc" font-size="28" font-weight="700">1022</text>
   </g>
   <g>
     <rect x="28" y="178" width="170" height="82" rx="16" fill="#111827" stroke="#334155"/>
-    <text x="46" y="212" fill="#94a3b8" font-size="13">Commits</text>
-    <text x="46" y="240" fill="#f8fafc" font-size="28" font-weight="700">3154</text>
+    <text x="46" y="212" fill="#94a3b8" font-size="13">Reviewed PRs</text>
+    <text x="46" y="240" fill="#f8fafc" font-size="28" font-weight="700">237</text>
   </g>
   <g>
     <rect x="219" y="178" width="170" height="82" rx="16" fill="#111827" stroke="#334155"/>
-    <text x="237" y="212" fill="#94a3b8" font-size="13">Pull requests</text>
-    <text x="237" y="240" fill="#f8fafc" font-size="28" font-weight="700">1249</text>
+    <text x="237" y="212" fill="#94a3b8" font-size="13">Accessible repos</text>
+    <text x="237" y="240" fill="#f8fafc" font-size="28" font-weight="700">112</text>
   </g>
   <g>
     <rect x="410" y="178" width="170" height="82" rx="16" fill="#111827" stroke="#334155"/>
-    <text x="428" y="212" fill="#94a3b8" font-size="13">Issues</text>
-    <text x="428" y="240" fill="#f8fafc" font-size="28" font-weight="700">1021</text>
+    <text x="428" y="212" fill="#94a3b8" font-size="13">Repos touched</text>
+    <text x="428" y="240" fill="#f8fafc" font-size="28" font-weight="700">104</text>
   </g>
   <g>
     <rect x="601" y="178" width="170" height="82" rx="16" fill="#111827" stroke="#334155"/>
-    <text x="619" y="212" fill="#94a3b8" font-size="13">Reviewed PRs</text>
-    <text x="619" y="240" fill="#f8fafc" font-size="28" font-weight="700">230</text>
-  </g>
-  <g>
-    <rect x="28" y="270" width="170" height="82" rx="16" fill="#111827" stroke="#334155"/>
-    <text x="46" y="304" fill="#94a3b8" font-size="13">Repos touched</text>
-    <text x="46" y="332" fill="#f8fafc" font-size="28" font-weight="700">104</text>
+    <text x="619" y="212" fill="#94a3b8" font-size="13">Top stack</text>
+    <text x="619" y="240" fill="#f8fafc" font-size="22" font-weight="700">PowerShell x28</text>
   </g>
 </svg>

--- a/docs/private-contribution-stats.md
+++ b/docs/private-contribution-stats.md
@@ -7,9 +7,6 @@ This profile repository can publish aggregate-only activity across accessible re
 The generated SVG may publish:
 
 - Total activity over the last year
-- Current activity streak
-- Longest activity streak
-- Active activity days
 - Commit, authored pull request, authored issue, and reviewed pull request totals
 - Total accessible repository count
 - Private and public repository counts
@@ -57,6 +54,6 @@ This is intended to represent practical work across public and private repositor
 
 ## Updating Stats
 
-The `Private Contribution Stats` workflow runs on a daily schedule and can also be run manually.
+The `All Activity Signals` workflow runs once per day and can also be run manually. A daily run keeps the profile fresh while staying comfortably within normal GitHub Actions usage for a public profile repository.
 
 When the generated SVG changes, the workflow opens a pull request instead of pushing directly to `main`.

--- a/scripts/generate_private_contribution_stats.py
+++ b/scripts/generate_private_contribution_stats.py
@@ -27,7 +27,6 @@ from urllib.request import Request, urlopen
 API_ROOT = "https://api.github.com"
 REQUEST_TIMEOUT_SECONDS = 20
 REQUEST_RETRIES = 1
-SEARCH_DATE_SAMPLE_PAGES = 5
 
 
 def parse_args() -> argparse.Namespace:
@@ -107,7 +106,7 @@ def fetch_accessible_repositories(token: str) -> list[dict[str, Any]]:
 
 def fetch_commit_activity(
     repositories: list[dict[str, Any]], token: str, username: str, since: datetime
-) -> tuple[int, Counter[str]]:
+) -> int:
     _ = repositories
     since_date = since.date().isoformat()
     query = f"author:{username} committer-date:>={since_date}"
@@ -120,103 +119,26 @@ def fetch_commit_activity(
         }
     )
     url = f"{API_ROOT}/search/commits?{params}"
-    activity_dates: Counter[str] = Counter()
 
-    total = 0
-    sampled_pages = 0
-    while url and sampled_pages < SEARCH_DATE_SAMPLE_PAGES:
-        sampled_pages += 1
-        try:
-            payload, headers = request_json(url, token)
-        except RuntimeError as error:
-            if "timed out" in str(error):
-                break
-            raise
-        if not isinstance(payload, dict) or not isinstance(payload.get("items"), list):
-            raise RuntimeError("Unexpected GitHub API response for search/commits")
-
-        total = max(total, int(payload.get("total_count", 0)))
-        for item in payload["items"]:
-            commit_date = (
-                item.get("commit", {}).get("author", {}).get("date")
-                or item.get("commit", {}).get("committer", {}).get("date")
-            )
-            parsed = parse_github_datetime(commit_date)
-            if parsed:
-                activity_dates[parsed.date().isoformat()] += 1
-
-        url = parse_link_header(headers.get("link")).get("next", "")
-
-    return total, activity_dates
+    payload, _headers = request_json(url, token)
+    if not isinstance(payload, dict):
+        raise RuntimeError("Unexpected GitHub API response for search/commits")
+    return int(payload.get("total_count", 0))
 
 
-def fetch_search_activity(
-    token: str, query: str, date_field: str
-) -> tuple[int, Counter[str]]:
+def fetch_search_activity(token: str, query: str) -> int:
     params = urlencode({"q": query, "per_page": "100", "sort": "created", "order": "desc"})
     url = f"{API_ROOT}/search/issues?{params}"
-    total = 0
-    activity_dates: Counter[str] = Counter()
-
-    sampled_pages = 0
-    while url and sampled_pages < SEARCH_DATE_SAMPLE_PAGES:
-        sampled_pages += 1
-        try:
-            payload, headers = request_json(url, token)
-        except RuntimeError as error:
-            if "timed out" in str(error):
-                break
-            raise
-        if not isinstance(payload, dict) or not isinstance(payload.get("items"), list):
-            raise RuntimeError("Unexpected GitHub API response for search/issues")
-
-        total = max(total, int(payload.get("total_count", 0)))
-        for item in payload["items"]:
-            parsed = parse_github_datetime(item.get(date_field))
-            if parsed:
-                activity_dates[parsed.date().isoformat()] += 1
-
-        url = parse_link_header(headers.get("link")).get("next", "")
-
-    return total, activity_dates
+    payload, _headers = request_json(url, token)
+    if not isinstance(payload, dict):
+        raise RuntimeError("Unexpected GitHub API response for search/issues")
+    return int(payload.get("total_count", 0))
 
 
 def parse_github_datetime(value: str | None) -> datetime | None:
     if not value:
         return None
     return datetime.fromisoformat(value.replace("Z", "+00:00"))
-
-
-def calculate_streaks(activity_dates: Counter[str], since: datetime, today: datetime) -> dict[str, int]:
-    parsed_days = []
-    current_day = since.date()
-    end_day = today.date()
-    while current_day <= end_day:
-        parsed_days.append((current_day, activity_dates[current_day.isoformat()]))
-        current_day += timedelta(days=1)
-
-    longest = 0
-    running = 0
-    for _, count in parsed_days:
-        if count > 0:
-            running += 1
-            longest = max(longest, running)
-        else:
-            running = 0
-
-    current = 0
-    relevant_days = parsed_days
-    if parsed_days and parsed_days[-1][1] == 0:
-        # GitHub cards commonly keep an active streak alive until yesterday when
-        # today's contribution count is still zero.
-        relevant_days = parsed_days[:-1]
-    for _, count in reversed(relevant_days):
-        if count <= 0:
-            break
-        current += 1
-
-    active_days = sum(1 for _, count in parsed_days if count > 0)
-    return {"current": current, "longest": longest, "active_days": active_days}
 
 
 def collect_activity(
@@ -226,29 +148,23 @@ def collect_activity(
     since = now - timedelta(days=days)
     since_date = since.date().isoformat()
 
-    commit_count, activity_dates = fetch_commit_activity(repositories, token, username, since)
+    commit_count = fetch_commit_activity(repositories, token, username, since)
 
-    authored_pr_count, pr_dates = fetch_search_activity(
-        token, f"author:{username} type:pr created:>={since_date}", "created_at"
+    authored_pr_count = fetch_search_activity(
+        token, f"author:{username} type:pr created:>={since_date}"
     )
-    issue_count, issue_dates = fetch_search_activity(
-        token, f"author:{username} type:issue created:>={since_date}", "created_at"
+    issue_count = fetch_search_activity(
+        token, f"author:{username} type:issue created:>={since_date}"
     )
-    reviewed_pr_count, review_dates = fetch_search_activity(
-        token, f"reviewed-by:{username} type:pr updated:>={since_date}", "updated_at"
+    reviewed_pr_count = fetch_search_activity(
+        token, f"reviewed-by:{username} type:pr updated:>={since_date}"
     )
-
-    activity_dates.update(pr_dates)
-    activity_dates.update(issue_dates)
-    activity_dates.update(review_dates)
 
     return {
         "commit_count": commit_count,
         "authored_pr_count": authored_pr_count,
         "issue_count": issue_count,
         "reviewed_pr_count": reviewed_pr_count,
-        "activity_dates": activity_dates,
-        "streaks": calculate_streaks(activity_dates, since, now),
     }
 
 
@@ -277,9 +193,10 @@ def summarize(
     top_languages = ", ".join(
         f"{language} x{count}" for language, count in language_counts.most_common(4)
     )
+    top_language = language_counts.most_common(1)[0] if language_counts else None
+    top_stack = f"{top_language[0]} x{top_language[1]}" if top_language else "N/A"
 
     activity = activity or {}
-    streaks = activity.get("streaks") or {"current": 0, "longest": 0, "active_days": 0}
     commit_count = int(activity.get("commit_count", 0))
     authored_pr_count = int(activity.get("authored_pr_count", 0))
     issue_count = int(activity.get("issue_count", 0))
@@ -288,9 +205,6 @@ def summarize(
 
     return {
         "total_contributions": str(total_activity),
-        "current_streak": str(streaks["current"]),
-        "longest_streak": str(streaks["longest"]),
-        "active_days": str(streaks["active_days"]),
         "commit_contributions": str(commit_count),
         "pull_requests": str(authored_pr_count),
         "issues": str(issue_count),
@@ -301,6 +215,7 @@ def summarize(
         "active_90": str(active_90),
         "active_365": str(active_365),
         "organization_count": str(organization_count),
+        "top_stack": top_stack,
         "top_languages": top_languages or "No languages detected",
         "latest_update": max(updated_dates).strftime("%Y-%m-%d") if updated_dates else "N/A",
         "generated_at": now.strftime("%Y-%m-%d"),
@@ -315,9 +230,6 @@ def render_svg(summary: dict[str, str], *, username: str, configured: bool) -> s
     if not configured:
         summary = {
             "total_contributions": "Setup",
-            "current_streak": "Needed",
-            "longest_streak": "Needed",
-            "active_days": "Needed",
             "commit_contributions": "Needed",
             "pull_requests": "Needed",
             "issues": "Needed",
@@ -328,6 +240,7 @@ def render_svg(summary: dict[str, str], *, username: str, configured: bool) -> s
             "active_90": "Needed",
             "active_365": "Needed",
             "organization_count": "Needed",
+            "top_stack": "Needed",
             "top_languages": "Add PROFILE_STATS_TOKEN to generate aggregate activity signals",
             "latest_update": "N/A",
             "generated_at": datetime.now(UTC).strftime("%Y-%m-%d"),
@@ -335,14 +248,13 @@ def render_svg(summary: dict[str, str], *, username: str, configured: bool) -> s
 
     cards = [
         ("Total activity", summary["total_contributions"]),
-        ("Current streak", f'{summary["current_streak"]}d'),
-        ("Longest streak", f'{summary["longest_streak"]}d'),
-        ("Active days", summary["active_days"]),
         ("Commits", summary["commit_contributions"]),
         ("Pull requests", summary["pull_requests"]),
         ("Issues", summary["issues"]),
         ("Reviewed PRs", summary["reviews"]),
+        ("Accessible repos", summary["accessible_repos"]),
         ("Repos touched", summary["active_365"]),
+        ("Top stack", summary["top_stack"]),
     ]
     card_svg = []
     for index, (label, value) in enumerate(cards):
@@ -350,16 +262,17 @@ def render_svg(summary: dict[str, str], *, username: str, configured: bool) -> s
         column = index % 4
         x = 28 + column * 191
         y = 86 + row * 92
+        value_font_size = 22 if label == "Top stack" else 28
         card_svg.append(
             f"""
   <g>
     <rect x="{x}" y="{y}" width="170" height="82" rx="16" fill="#111827" stroke="#334155"/>
     <text x="{x + 18}" y="{y + 34}" fill="#94a3b8" font-size="13">{text(label)}</text>
-    <text x="{x + 18}" y="{y + 62}" fill="#f8fafc" font-size="28" font-weight="700">{text(value)}</text>
+    <text x="{x + 18}" y="{y + 62}" fill="#f8fafc" font-size="{value_font_size}" font-weight="700">{text(value)}</text>
   </g>"""
         )
 
-    return f"""<svg xmlns="http://www.w3.org/2000/svg" width="820" height="460" viewBox="0 0 820 460" role="img" aria-labelledby="title desc">
+    return f"""<svg xmlns="http://www.w3.org/2000/svg" width="820" height="388" viewBox="0 0 820 388" role="img" aria-labelledby="title desc">
   <title id="title">Aggregate activity stats for {text(username)}</title>
   <desc id="desc">Aggregate activity across accessible repositories. Repository names and URLs are not included.</desc>
   <defs>
@@ -374,13 +287,13 @@ def render_svg(summary: dict[str, str], *, username: str, configured: bool) -> s
       <stop offset="100%" stop-color="#f97316"/>
     </linearGradient>
   </defs>
-  <rect width="820" height="460" rx="24" fill="url(#bg)"/>
-  <rect x="1" y="1" width="818" height="458" rx="23" fill="none" stroke="#334155"/>
+  <rect width="820" height="388" rx="24" fill="url(#bg)"/>
+  <rect x="1" y="1" width="818" height="386" rx="23" fill="none" stroke="#334155"/>
   <rect x="28" y="30" width="186" height="8" rx="4" fill="url(#accent)"/>
   <text x="28" y="66" fill="#f8fafc" font-family="Segoe UI, Inter, Arial, sans-serif" font-size="26" font-weight="700">All Activity Signals</text>
-  <text x="28" y="386" fill="#cbd5e1" font-family="Segoe UI, Inter, Arial, sans-serif" font-size="14">Accessible repos: {text(summary["accessible_repos"])} total / {text(summary["private_repos"])} private / {text(summary["public_repos"])} public / {text(summary["organization_count"])} org workspaces</text>
-  <text x="28" y="410" fill="#cbd5e1" font-family="Segoe UI, Inter, Arial, sans-serif" font-size="14">Top stack across accessible repos: {text(summary["top_languages"])}</text>
-  <text x="28" y="436" fill="#94a3b8" font-family="Segoe UI, Inter, Arial, sans-serif" font-size="12">Aggregate only. No repository names, URLs, issue titles, or commit messages are published. Latest repo activity: {text(summary["latest_update"])}. Generated: {text(summary["generated_at"])}.</text>
+  <text x="28" y="314" fill="#cbd5e1" font-family="Segoe UI, Inter, Arial, sans-serif" font-size="14">Stack detail: {text(summary["top_languages"])}</text>
+  <text x="28" y="340" fill="#94a3b8" font-family="Segoe UI, Inter, Arial, sans-serif" font-size="12">Repo split: {text(summary["private_repos"])} private / {text(summary["public_repos"])} public / {text(summary["organization_count"])} org workspaces. Daily automation-friendly aggregate.</text>
+  <text x="28" y="362" fill="#94a3b8" font-family="Segoe UI, Inter, Arial, sans-serif" font-size="12">No repository names, URLs, issue titles, or commit messages are published. Latest repo activity: {text(summary["latest_update"])}. Generated: {text(summary["generated_at"])}.</text>
   {''.join(card_svg)}
 </svg>
 """


### PR DESCRIPTION
## Summary

- Current streak / Longest streak / Active days を `All Activity Signals` から削除しました。
- `Accessible repos` と `Top stack` をメインカードに昇格し、repo split と stack detail は補足行に残しました。
- Actions の自動更新は daily 1 回を明記し、search API の `total_count` 利用に寄せて生成処理を軽くしました。

## Test Plan

- Docker: `python scripts/generate_private_contribution_stats.py --output assets/private-contributions.svg --username mashfromband`
- Docker: `python -c "import ast, pathlib; ast.parse(pathlib.Path(''scripts/generate_private_contribution_stats.py'').read_text(encoding=''utf-8''))"`
- `rg "Current streak|Longest streak|Active days|streaks"` で非表示対象の残存なしを確認
- Cursor lints: edited files でエラーなし

Closes #12
