### PR TITLE
ci: make required status checks reliable for all PRs and automation

### DIFF
--- a/.github/workflows/private-contribution-stats.yml
+++ b/.github/workflows/private-contribution-stats.yml
@@ -41,6 +41,9 @@ jobs:
         if: ${{ env.PROFILE_STATS_TOKEN != '' }}
         uses: peter-evans/create-pull-request@v7
         with:
+          # Use a PAT (not GITHUB_TOKEN) so the automation PR triggers the
+          # required status checks; PRs opened by GITHUB_TOKEN do not.
+          token: ${{ secrets.PROFILE_STATS_TOKEN }}
           branch: automation/all-activity-signals
           title: "chore: update all activity signals"
           commit-message: "chore: update all activity signals"

--- a/.github/workflows/profile-readme.yml
+++ b/.github/workflows/profile-readme.yml
@@ -1,18 +1,13 @@
 name: Profile README Quality
 
 on:
+  # Run on every pull request and push to main (no path filter) so the
+  # "Markdown links" check always reports a status and can serve as a required
+  # status check without deadlocking PRs that do not touch README.md.
   pull_request:
-    paths:
-      - "README.md"
-      - "assets/private-contributions.svg"
-      - ".github/workflows/profile-readme.yml"
   push:
     branches:
       - main
-    paths:
-      - "README.md"
-      - "assets/private-contributions.svg"
-      - ".github/workflows/profile-readme.yml"
 
 permissions:
   contents: read

--- a/docs/private-contribution-stats.md
+++ b/docs/private-contribution-stats.md
@@ -97,7 +97,10 @@ manually. A daily run keeps the profile fresh while staying comfortably within
 normal GitHub Actions usage for a public profile repository.
 
 When the generated SVG changes, the workflow opens a pull request instead of
-pushing directly to `main`.
+pushing directly to `main`. The pull request is created with
+`PROFILE_STATS_TOKEN` (a PAT) rather than the default `GITHUB_TOKEN`, so the
+required status checks run on it; pull requests opened by `GITHUB_TOKEN` do not
+trigger workflows.
 
 If `PROFILE_STATS_TOKEN` is not configured, the workflow reports a warning and
 skips the refresh steps. This keeps the scheduled workflow green without


### PR DESCRIPTION
## Summary

必須チェック化（#17）に伴って判明した、必須ステータスチェックが一部 PR で永久に未報告になりマージ不能（BLOCKED）になる問題を恒久対処します。

## Problem

- `Markdown links` が path フィルタ付きのため、README を触らない PR（例: workflow のみ変更の dependabot PR #14）では起動せず、必須チェックが未報告 → BLOCKED。
- 日次自動更新 PR（#15）は `GITHUB_TOKEN` 作成のため**他ワークフローを起動しない**仕様で、必須チェックが走らず BLOCKED。

## Changes

- **ci**: `profile-readme.yml` の path フィルタを除去し、`Markdown links` を全 PR / main 全 push で実行（常に status を報告）。
- **ci**: 自動更新ワークフローの `peter-evans/create-pull-request` に `token: ${{ secrets.PROFILE_STATS_TOKEN }}`（PAT）を指定し、生成される PR が必須チェックを起動するように。
- **docs**: 上記の理由を `docs/private-contribution-stats.md` に明記。

## Effect

- #14 / 今後の workflow-only PR、および日次自動更新 PR（#15 系）で必須チェックが走り、マージ可能になる。
- 既存の必須チェック（`Markdown links` / `Python unit tests`）の運用が全 PR で一貫。

## Notes

- `PROFILE_STATS_TOKEN` は classic PAT（`repo` + `read:user`）で、ブランチ push と PR 作成に必要な権限を満たす。
