### PR TITLE
feat: show stack name only on Top stack card

### DIFF
--- a/assets/private-contributions.svg
+++ b/assets/private-contributions.svg
@@ -59,6 +59,6 @@
   <g>
     <rect x="601" y="178" width="170" height="82" rx="16" fill="#111827" stroke="#334155"/>
     <text x="619" y="212" fill="#94a3b8" font-size="13">Top stack</text>
-    <text x="619" y="240" fill="#f8fafc" font-size="22" font-weight="700">TypeScript x24</text>
+    <text x="619" y="240" fill="#f8fafc" font-size="22" font-weight="700">TypeScript</text>
   </g>
 </svg>

--- a/scripts/generate_private_contribution_stats.py
+++ b/scripts/generate_private_contribution_stats.py
@@ -219,7 +219,8 @@ def summarize(
         f"{language} x{count}" for language, count in language_counts.most_common(4)
     )
     top_language = language_counts.most_common(1)[0] if language_counts else None
-    top_stack = f"{top_language[0]} x{top_language[1]}" if top_language else "N/A"
+    # Top stack card shows the stack name only (no count).
+    top_stack = top_language[0] if top_language else "N/A"
 
     activity = activity or {}
     commit_count = int(activity.get("commit_count", 0))

--- a/tests/test_generate_private_contribution_stats.py
+++ b/tests/test_generate_private_contribution_stats.py
@@ -58,7 +58,7 @@ class SummarizeTests(unittest.TestCase):
 
     def test_excludes_powershell_and_unknown_language(self) -> None:
         summary = gen.summarize(self._repos(), {"total_contributions": 100})
-        self.assertEqual(summary["top_stack"], "Python x1")
+        self.assertEqual(summary["top_stack"], "Python")
         self.assertNotIn("PowerShell", summary["top_languages"])
 
     def test_aggregate_repo_counts(self) -> None:


### PR DESCRIPTION
## Summary

Top stack カードの値からリポジトリ数を除き、スタック名のみ表示にします（例: `TypeScript x24` → `TypeScript`）。言語別カウントは Stack detail フッターに残します。

## Changes

- scripts: top_stack をスタック名のみに変更
- tests: 期待値を更新
- assets: 既存 SVG の Top stack カード値を更新（数値は本番ワークフロー再生成で完全反映）
