### PR TITLE
docs: document org access requirement for full contribution counts

### DIFF
--- a/assets/private-contributions.svg
+++ b/assets/private-contributions.svg
@@ -18,7 +18,7 @@
   <rect x="28" y="30" width="186" height="8" rx="4" fill="url(#accent)"/>
   <text x="28" y="66" fill="#f8fafc" font-family="Segoe UI, Inter, Arial, sans-serif" font-size="26" font-weight="700">All Activity Signals</text>
   <text x="28" y="314" fill="#cbd5e1" font-family="Segoe UI, Inter, Arial, sans-serif" font-size="14">Stack detail: TypeScript x24, JavaScript x24, Python x12, HTML x4</text>
-  <text x="28" y="340" fill="#94a3b8" font-family="Segoe UI, Inter, Arial, sans-serif" font-size="12">Repo split: 106 private / 5 public / 12 org workspaces. Mirrors the owner self view (last 365 days); totals include private contributions.</text>
+  <text x="28" y="340" fill="#94a3b8" font-family="Segoe UI, Inter, Arial, sans-serif" font-size="12">Repo split: 106 private / 5 public / 12 org workspaces. Last 365 days; private included; some org contributions not counted.</text>
   <text x="28" y="362" fill="#94a3b8" font-family="Segoe UI, Inter, Arial, sans-serif" font-size="12">No repository names, URLs, issue titles, or commit messages are published. Latest repo activity: 2026-06-28. Generated: 2026-06-28.</text>
   
   <g>

--- a/docs/private-contribution-stats.md
+++ b/docs/private-contribution-stats.md
@@ -49,6 +49,28 @@ Required access for full fidelity:
 Without private repository access the query still succeeds, but private
 contributions are reported as part of the public totals only.
 
+### Organization access (required for org contributions)
+
+`contributionsCollection` only counts contributions in organizations the token
+can actually access. Contributions made in an organization are **silently
+excluded** from the totals when the token cannot read that organization, which
+causes an undercount versus the owner's signed-in profile view. For every
+organization whose activity should be counted, ensure:
+
+- **SAML SSO authorization**: if the organization enforces SAML single sign-on,
+  the token must be authorized for it. Settings → Developer settings → Personal
+  access tokens → select the token → **Configure SSO** → Authorize for each
+  organization. (For fine-grained tokens, grant the token to the organization
+  as the resource owner.)
+- **Organization PAT policy**: the organization must allow access via personal
+  access tokens. Organization Settings → Third-party Access / Personal access
+  tokens → allow (or approve) the token. Classic-PAT access can be restricted at
+  the org level.
+- **Membership**: the token owner must be a member (or collaborator) of the org.
+
+To verify which organizations are actually counted, run the diagnostic in the
+Counting Model section below with the token.
+
 ## Counting Model
 
 The script reads the GraphQL `contributionsCollection` for the configured user,
@@ -71,6 +93,21 @@ Repository metadata (accessible repository count, private/public split,
 organization workspace count, and stack detection) comes from the REST
 `/user/repos` endpoint with `affiliation=owner,collaborator,organization_member`,
 so activity across every repository you are involved in is counted.
+
+### Diagnosing missing organizations
+
+If the total is lower than the signed-in profile view, list the repositories the
+token actually counts and confirm the expected organizations appear. Run with
+the same token configured as `PROFILE_STATS_TOKEN` (replace `TOKEN`):
+
+```bash
+curl -s -H "Authorization: Bearer TOKEN" https://api.github.com/graphql -d '{
+  "query": "query { viewer { contributionsCollection { contributionCalendar { totalContributions } commitContributionsByRepository(maxRepositories: 100) { repository { nameWithOwner isPrivate } contributions { totalCount } } } } }"
+}'
+```
+
+Organizations that are missing from the output are not accessible to the token —
+fix their access per the "Organization access" steps above, then re-run.
 
 ### Stack detection
 

--- a/docs/private-contribution-stats.md
+++ b/docs/private-contribution-stats.md
@@ -5,6 +5,11 @@ statistics GitHub shows to the signed-in owner ("self view") in
 `assets/private-contributions.svg`. The numbers include private contributions,
 which public profile cards cannot read.
 
+Contributions made in organizations the token cannot access are intentionally
+not counted, so the published total can be lower than the owner's signed-in
+profile view. The SVG states this, and the steps to include an organization are
+in [Organization access](#organization-access-required-for-org-contributions).
+
 ## Privacy Model
 
 The generated SVG may publish:

--- a/docs/private-contribution-stats.md
+++ b/docs/private-contribution-stats.md
@@ -14,7 +14,7 @@ in [Organization access](#organization-access-required-for-org-contributions).
 
 The generated SVG may publish:
 
-- Total contributions over the last year (self-view total, private included)
+- Total contributions over the last year (private included; mirrors the owner self view for accessible organizations)
 - Commit, authored pull request, authored issue, and pull request review totals
 - Total accessible repository count
 - Private and public repository counts

--- a/scripts/generate_private_contribution_stats.py
+++ b/scripts/generate_private_contribution_stats.py
@@ -320,7 +320,7 @@ def render_svg(summary: dict[str, str], *, username: str, configured: bool) -> s
   <rect x="28" y="30" width="186" height="8" rx="4" fill="url(#accent)"/>
   <text x="28" y="66" fill="#f8fafc" font-family="Segoe UI, Inter, Arial, sans-serif" font-size="26" font-weight="700">All Activity Signals</text>
   <text x="28" y="314" fill="#cbd5e1" font-family="Segoe UI, Inter, Arial, sans-serif" font-size="14">Stack detail: {text(summary["top_languages"])}</text>
-  <text x="28" y="340" fill="#94a3b8" font-family="Segoe UI, Inter, Arial, sans-serif" font-size="12">Repo split: {text(summary["private_repos"])} private / {text(summary["public_repos"])} public / {text(summary["organization_count"])} org workspaces. Mirrors the owner self view (last 365 days); totals include private contributions.</text>
+  <text x="28" y="340" fill="#94a3b8" font-family="Segoe UI, Inter, Arial, sans-serif" font-size="12">Repo split: {text(summary["private_repos"])} private / {text(summary["public_repos"])} public / {text(summary["organization_count"])} org workspaces. Last 365 days; private included; some org contributions not counted.</text>
   <text x="28" y="362" fill="#94a3b8" font-family="Segoe UI, Inter, Arial, sans-serif" font-size="12">No repository names, URLs, issue titles, or commit messages are published. Latest repo activity: {text(summary["latest_update"])}. Generated: {text(summary["generated_at"])}.</text>
   {''.join(card_svg)}
 </svg>


### PR DESCRIPTION
## Summary

所属組織（ripla-inc / RealizeLearning / autoselling / GovNoa 等）の private コントリビュートが `contributionsCollection` の総数に反映されず、サインイン時のプロフィール表示より過少カウントになる問題の原因と対処を文書化。

## Root cause

`contributionsCollection` はトークンがアクセスできない組織のコントリビュートを**サイレントに除外**する。原因は (a) 組織の SAML SSO に対しトークンが未認可、または (b) 組織の classic PAT アクセスポリシーで不許可。コード側のバグではなくトークンの組織アクセス権限の問題。

## Changes

- docs: `Token Setup` に「Organization access（SSO 認可・組織 PAT ポリシー・メンバーシップ）」要件を追記
- docs: `Counting Model` に、実際にカウントされている repo/組織を一覧する診断クエリを追記

## Note

実データ修正にはオーナーによるトークンの SSO 認可（外部操作）が必要。
