### PR TITLE
chore: update all activity signals

### DIFF
--- a/assets/private-contributions.svg
+++ b/assets/private-contributions.svg
@@ -24,27 +24,27 @@
   <g>
     <rect x="28" y="86" width="170" height="82" rx="16" fill="#111827" stroke="#334155"/>
     <text x="46" y="120" fill="#94a3b8" font-size="13">Total contributions</text>
-    <text x="46" y="148" fill="#f8fafc" font-size="28" font-weight="700">8220</text>
+    <text x="46" y="148" fill="#f8fafc" font-size="28" font-weight="700">8236</text>
   </g>
   <g>
     <rect x="219" y="86" width="170" height="82" rx="16" fill="#111827" stroke="#334155"/>
     <text x="237" y="120" fill="#94a3b8" font-size="13">Commits</text>
-    <text x="237" y="148" fill="#f8fafc" font-size="28" font-weight="700">4158</text>
+    <text x="237" y="148" fill="#f8fafc" font-size="28" font-weight="700">4167</text>
   </g>
   <g>
     <rect x="410" y="86" width="170" height="82" rx="16" fill="#111827" stroke="#334155"/>
     <text x="428" y="120" fill="#94a3b8" font-size="13">Pull requests</text>
-    <text x="428" y="148" fill="#f8fafc" font-size="28" font-weight="700">1848</text>
+    <text x="428" y="148" fill="#f8fafc" font-size="28" font-weight="700">1850</text>
   </g>
   <g>
     <rect x="601" y="86" width="170" height="82" rx="16" fill="#111827" stroke="#334155"/>
     <text x="619" y="120" fill="#94a3b8" font-size="13">Issues</text>
-    <text x="619" y="148" fill="#f8fafc" font-size="28" font-weight="700">1723</text>
+    <text x="619" y="148" fill="#f8fafc" font-size="28" font-weight="700">1726</text>
   </g>
   <g>
     <rect x="28" y="178" width="170" height="82" rx="16" fill="#111827" stroke="#334155"/>
     <text x="46" y="212" fill="#94a3b8" font-size="13">Code reviews</text>
-    <text x="46" y="240" fill="#f8fafc" font-size="28" font-weight="700">478</text>
+    <text x="46" y="240" fill="#f8fafc" font-size="28" font-weight="700">480</text>
   </g>
   <g>
     <rect x="219" y="178" width="170" height="82" rx="16" fill="#111827" stroke="#334155"/>


### PR DESCRIPTION
## Summary

- Regenerate aggregate-only activity signals for the profile README.
- Runs daily to keep the profile current without publishing private repository details.

## Privacy

- Private repository names, URLs, issue titles, and commit messages are not written to the SVG.